### PR TITLE
Add PostRobot model

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,7 +77,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Robot'
+                  $ref: '#/components/schemas/GetRobot'
           description: Request successful
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -152,7 +152,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Robot'
+                $ref: '#/components/schemas/GetRobot'
           description: Request successful and robot returned
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -831,7 +831,6 @@ components:
     Robot:
       type: object
       required:
-      - id
       - name
       - model
       - serial_number
@@ -841,11 +840,6 @@ components:
       - enabled
       - capabilities
       properties:
-        id:
-          type: integer
-          format: int32
-          description: Id of robot
-          example: 1
         name:
           type: string
           description: Name of robot
@@ -869,7 +863,7 @@ components:
           example: 3000
         enabled:
           type: boolean
-          description: Wheter the robot is enabled and available for scheduling missions
+          description: Whether the robot is enabled and available for scheduling missions
           example: true
         status:
           type: string
@@ -888,6 +882,18 @@ components:
             - image
             - audio
       additionalProperties: false
+    GetRobot:
+      allOf:
+        - $ref: "#/components/schemas/Robot"
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int32
+              description: Id of robot
+              example: 1
     Mission:
       type: object
       required:


### PR DESCRIPTION
Required fields are not the same for a POST and GET robot. Therefore, a
separate robot model is created for get robots.